### PR TITLE
Add the split strategy to regression class

### DIFF
--- a/mapie/regression.py
+++ b/mapie/regression.py
@@ -63,8 +63,8 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         - integer, to specify the number of folds.
           - If equal to -1, equivalent to
           ``sklearn.model_selection.LeaveOneOut()``.
-          - If equal to 1, does not involve cross-validation but a division 
-          of the data into training and calibration subsets. The splitter 
+          - If equal to 1, does not involve cross-validation but a division
+          of the data into training and calibration subsets. The splitter
           used is the following: ``sklearn.model_selection.ShuffleSplit``.
         - CV splitter: any ``sklearn.model_selection.BaseCrossValidator``
           Main variants are:
@@ -547,7 +547,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
             self.single_estimator_ = fit_estimator(
                 clone(estimator), X, y, sample_weight
             )
-            
+
             if self.method == "naive":
                 y_pred = self.single_estimator_.predict(X)
             else:
@@ -656,7 +656,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
 
         alpha_np = cast(NDArray, alpha)
         check_alpha_and_n_samples(alpha_np, n)
-        
+
         if self.method in ["naive", "base"] or self.cv == "prefit":
             y_pred_multi_low = y_pred[:, np.newaxis]
             y_pred_multi_up = y_pred[:, np.newaxis]
@@ -669,7 +669,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
             else:
                 y_pred_multi_low = y_pred_multi
                 y_pred_multi_up = y_pred_multi
-            
+
             if ensemble:
                 y_pred = aggregate_all(self.agg_function, y_pred_multi)
 
@@ -681,7 +681,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
             conformity_scores_low = self.conformity_scores_
             conformity_scores_up = self.conformity_scores_
             alpha_np = alpha_np / 2
-        
+
         lower_bounds = (
             self.conformity_score_function_.get_estimation_distribution(
                 y_pred_multi_low, conformity_scores_low

--- a/mapie/regression.py
+++ b/mapie/regression.py
@@ -32,8 +32,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
     idea is to evaluate out-of-fold conformity scores (signed residuals,
     absolute residuals, residuals normalized by the predicted mean...)
     on hold-out validation sets and to deduce valid confidence intervals
-    with strong theoretical
-    guarantees.
+    with strong theoretical guarantees.
 
     Parameters
     ----------
@@ -62,8 +61,11 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
 
         - ``None``, to use the default 5-fold cross-validation
         - integer, to specify the number of folds.
-          If equal to -1, equivalent to
+          - If equal to -1, equivalent to
           ``sklearn.model_selection.LeaveOneOut()``.
+          - If equal to 1, does not involve cross-validation but a division 
+          of the data into training and calibration subsets. The splitter 
+          used is the following: ``sklearn.model_selection.ShuffleSplit``.
         - CV splitter: any ``sklearn.model_selection.BaseCrossValidator``
           Main variants are:
           - ``sklearn.model_selection.LeaveOneOut`` (jackknife),
@@ -112,7 +114,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         Jackknife+-after-Bootstrap method), this function is also used to
         aggregate the training set in-sample predictions.
 
-        If cv is ``"prefit"``, ``agg_function`` is ignored.
+        If cv is ``"prefit"`` or ``"split"``, ``agg_function`` is ignored.
 
         By default "mean".
 
@@ -165,7 +167,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
     Rina Foygel Barber, Emmanuel J. Candès,
     Aaditya Ramdas, and Ryan J. Tibshirani.
     "Predictive inference with the jackknife+."
-    Ann. Statist., 49(1):486–507, February 2021.
+    Ann. Statist., 49(1):486-507, February 2021.
 
     Byol Kim, Chen Xu, and Rina Foygel Barber.
     "Predictive Inference Is Free with the Jackknife+-after-Bootstrap."
@@ -275,7 +277,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
                 "You need to specify an aggregation function when "
                 f"cv's type is in {self.cv_need_agg_function}."
             )
-        if (agg_function is not None) or (self.cv == "prefit"):
+        if (agg_function is not None) or (self.cv in ["prefit", "split"]):
             return agg_function
         return "mean"
 
@@ -542,15 +544,10 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
                 dtype=float,
             )
 
-            pred_matrix = np.full(
-                shape=(n_samples, cv.get_n_splits(X, y)),
-                fill_value=np.nan,
-                dtype=float,
-            )
-
             self.single_estimator_ = fit_estimator(
                 clone(estimator), X, y, sample_weight
             )
+            
             if self.method == "naive":
                 y_pred = self.single_estimator_.predict(X)
             else:
@@ -569,6 +566,11 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
                     list, zip(*outputs)
                 )
 
+                pred_matrix = np.full(
+                    shape=(n_samples, cv.get_n_splits(X, y)),
+                    fill_value=np.nan,
+                    dtype=float,
+                )
                 for i, val_ind in enumerate(val_indices):
                     pred_matrix[val_ind, i] = np.array(
                         predictions[i], dtype=float
@@ -614,7 +616,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
             the aggregation function specified in the ``agg_function``
             attribute.
 
-            If cv is ``"prefit"``, ``ensemble`` is ignored.
+            If cv is ``"prefit"`` or ``"split"``, ``ensemble`` is ignored.
 
             By default ``False``.
 
@@ -645,6 +647,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
         check_is_fitted(self, self.fit_attributes)
         self._check_ensemble(ensemble)
         alpha = cast(Optional[NDArray], check_alpha(alpha))
+
         y_pred = self.single_estimator_.predict(X)
         n = len(self.conformity_scores_)
 
@@ -653,6 +656,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
 
         alpha_np = cast(NDArray, alpha)
         check_alpha_and_n_samples(alpha_np, n)
+        
         if self.method in ["naive", "base"] or self.cv == "prefit":
             y_pred_multi_low = y_pred[:, np.newaxis]
             y_pred_multi_up = y_pred[:, np.newaxis]
@@ -665,6 +669,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
             else:
                 y_pred_multi_low = y_pred_multi
                 y_pred_multi_up = y_pred_multi
+            
             if ensemble:
                 y_pred = aggregate_all(self.agg_function, y_pred_multi)
 
@@ -676,6 +681,7 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
             conformity_scores_low = self.conformity_scores_
             conformity_scores_up = self.conformity_scores_
             alpha_np = alpha_np / 2
+        
         lower_bounds = (
             self.conformity_score_function_.get_estimation_distribution(
                 y_pred_multi_low, conformity_scores_low
@@ -698,17 +704,17 @@ class MapieRegressor(BaseEstimator, RegressorMixin):
                 )
                 for _alpha in alpha_np
             ]
-        ).data
+        )
         y_pred_up = np.column_stack(
             [
                 np_nanquantile(
                     upper_bounds.astype(float),
-                    1 - _alpha,
+                    1-_alpha,
                     axis=1,
                     method="higher",
                 )
                 for _alpha in alpha_np
             ]
-        ).data
+        )
 
         return y_pred, np.stack([y_pred_low, y_pred_up], axis=1)

--- a/mapie/tests/test_common.py
+++ b/mapie/tests/test_common.py
@@ -158,7 +158,7 @@ def test_invalid_method(MapieEstimator: BaseEstimator, method: str) -> None:
 
 @pytest.mark.parametrize("MapieEstimator", MapieSimpleEstimators())
 @pytest.mark.parametrize(
-    "cv", [-3.14, -2, 0, 1, "cv", LinearRegression(), [1, 2]]
+    "cv", [-3.14, -2, 0, "cv", LinearRegression(), [2, 3]]
 )
 def test_invalid_cv(MapieEstimator: BaseEstimator, cv: Any) -> None:
     """Test that invalid cv raise errors."""

--- a/mapie/tests/test_regression.py
+++ b/mapie/tests/test_regression.py
@@ -11,7 +11,7 @@ from sklearn.datasets import make_regression
 from sklearn.dummy import DummyRegressor
 from sklearn.impute import SimpleImputer
 from sklearn.linear_model import LinearRegression
-from sklearn.model_selection import (KFold, LeaveOneOut, 
+from sklearn.model_selection import (KFold, LeaveOneOut,
                                      ShuffleSplit, train_test_split)
 from sklearn.pipeline import Pipeline, make_pipeline
 from sklearn.preprocessing import OneHotEncoder

--- a/mapie/tests/test_regression.py
+++ b/mapie/tests/test_regression.py
@@ -11,7 +11,8 @@ from sklearn.datasets import make_regression
 from sklearn.dummy import DummyRegressor
 from sklearn.impute import SimpleImputer
 from sklearn.linear_model import LinearRegression
-from sklearn.model_selection import KFold, LeaveOneOut, train_test_split
+from sklearn.model_selection import (KFold, LeaveOneOut, 
+                                     ShuffleSplit, train_test_split)
 from sklearn.pipeline import Pipeline, make_pipeline
 from sklearn.preprocessing import OneHotEncoder
 from sklearn.utils.validation import check_is_fitted
@@ -42,10 +43,31 @@ Params = TypedDict(
     },
 )
 STRATEGIES = {
-    "naive": Params(method="naive", agg_function="median", cv=None),
-    "jackknife": Params(method="base", agg_function="mean", cv=-1),
-    "jackknife_plus": Params(method="plus", agg_function="mean", cv=-1),
-    "jackknife_minmax": Params(method="minmax", agg_function="mean", cv=-1),
+    "naive": Params(
+        method="naive",
+        agg_function="median",
+        cv=None
+    ),
+    "split": Params(
+        method="base",
+        agg_function="median",
+        cv=ShuffleSplit(n_splits=1, test_size=0.1, random_state=1)
+    ),
+    "jackknife": Params(
+        method="base",
+        agg_function="mean",
+        cv=-1
+    ),
+    "jackknife_plus": Params(
+        method="plus",
+        agg_function="mean",
+        cv=-1
+    ),
+    "jackknife_minmax": Params(
+        method="minmax",
+        agg_function="mean",
+        cv=-1
+    ),
     "cv": Params(
         method="base",
         agg_function="mean",
@@ -74,15 +96,13 @@ STRATEGIES = {
     "jackknife_plus_median_ab": Params(
         method="plus",
         agg_function="median",
-        cv=Subsample(
-            n_resamplings=30,
-            random_state=1,
-        ),
+        cv=Subsample(n_resamplings=30, random_state=1),
     ),
 }
 
 WIDTHS = {
     "naive": 3.81,
+    "split": 4.33,
     "jackknife": 3.89,
     "jackknife_plus": 3.90,
     "jackknife_minmax": 3.96,
@@ -98,6 +118,7 @@ WIDTHS = {
 
 COVERAGES = {
     "naive": 0.952,
+    "split": 0.972,
     "jackknife": 0.952,
     "jackknife_plus": 0.952,
     "jackknife_minmax": 0.952,
@@ -159,7 +180,7 @@ def test_valid_agg_function(agg_function: str) -> None:
     mapie_reg.fit(X_toy, y_toy)
 
 
-@pytest.mark.parametrize("cv", [None, -1, 2, KFold(), LeaveOneOut()])
+@pytest.mark.parametrize("cv", [None, -1, 2, KFold(), LeaveOneOut(), 1])
 def test_valid_cv(cv: Any) -> None:
     """Test that valid cv raise no errors."""
     mapie = MapieRegressor(cv=cv)

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -6,7 +6,7 @@ import numpy as np
 from sklearn.base import ClassifierMixin, RegressorMixin
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import (BaseCrossValidator, KFold, LeaveOneOut,
-                                     BaseShuffleSplit, ShuffleSplit, 
+                                     BaseShuffleSplit, ShuffleSplit,
                                      train_test_split)
 from sklearn.pipeline import Pipeline
 from sklearn.utils import _safe_indexing

--- a/mapie/utils.py
+++ b/mapie/utils.py
@@ -6,6 +6,7 @@ import numpy as np
 from sklearn.base import ClassifierMixin, RegressorMixin
 from sklearn.linear_model import LogisticRegression
 from sklearn.model_selection import (BaseCrossValidator, KFold, LeaveOneOut,
+                                     BaseShuffleSplit, ShuffleSplit, 
                                      train_test_split)
 from sklearn.pipeline import Pipeline
 from sklearn.utils import _safe_indexing
@@ -158,13 +159,15 @@ def check_cv(
     if isinstance(cv, int):
         if cv == -1:
             return LeaveOneOut()
+        if cv == 1:
+            return ShuffleSplit(n_splits=1, test_size=0.1)
         if cv >= 2:
             return KFold(n_splits=cv)
-    if (
-        isinstance(cv, BaseCrossValidator)
-        or (cv == "prefit")
-        or (cv == "split")
-    ):
+    if isinstance(cv, BaseCrossValidator):
+        return cv
+    if isinstance(cv, BaseShuffleSplit):
+        return cv
+    if cv in ["prefit", "split"]:
         return cv
     raise ValueError(
         "Invalid cv argument. "


### PR DESCRIPTION
# Description

To make split conformal predictions, you have to pre-train a model on `X_train`, then use the `fit` method with the `cv=prefit` parameter with `MapieRegressor` on `X_calib`. This PR proposes to do it automatically when using the `fit` method with the `cv=1` parameter on `X = X_train U X_calib`.

Fixes #(issue)

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

- [ ] Modify tests in `test_regression.py` file to verify the changes when using `cv=1` (in particular: coverage, width)
- [ ] Check if other tests need to be modified.

# Checklist

- [ ] I have read the [contributing guidelines](https://github.com/simai-ml/MAPIE/blob/master/CONTRIBUTING.rst)
- [ ] I have updated the [HISTORY.rst](https://github.com/simai-ml/MAPIE/blob/master/HISTORY.rst) and [AUTHORS.rst](https://github.com/simai-ml/MAPIE/blob/master/AUTHORS.rst) files
- [ ] Linting passes successfully : `make lint`
- [ ] Typing passes successfully : `make type-check`
- [ ] Unit tests pass successfully : `make tests`
- [ ] Coverage is 100% : `make coverage`
- [ ] Documentation builds successfully : `make doc`